### PR TITLE
Remove rejected secrets permission from manifest

### DIFF
--- a/org.squidowl.halloy.json
+++ b/org.squidowl.halloy.json
@@ -14,8 +14,7 @@
         "--socket=fallback-x11",
         "--socket=pulseaudio",
         "--socket=wayland",
-        "--talk-name=org.freedesktop.Notifications",
-        "--talk-name=org.freedesktop.secrets"
+        "--talk-name=org.freedesktop.Notifications"
     ],
     "build-options": {
         "append-path" : "/usr/lib/sdk/rust-stable/bin"


### PR DESCRIPTION
Usage of `org.freedesktop.secrets` was [rejected](https://github.com/flathub/org.squidowl.halloy/issues/48).

Added docs to guide users on how to make keyrings work: https://halloy.chat/guides/keyring#access-in-flatpak