### PR TITLE
Switch to X11 due to issues with upstream compatibility with Wayland

### DIFF
--- a/org.squidowl.halloy.json
+++ b/org.squidowl.halloy.json
@@ -11,9 +11,8 @@
         "--device=dri",
         "--share=ipc",
         "--share=network",
-        "--socket=fallback-x11",
         "--socket=pulseaudio",
-        "--socket=wayland",
+        "--socket=x11",
         "--talk-name=org.freedesktop.Notifications"
     ],
     "build-options": {


### PR DESCRIPTION
Seeing [reports](https://github.com/squidowl/halloy/issues/2243) of issues with pasting in Wayland.

We're moving to drop the socket to wayland and just using x11 for now. Until wayland is better supported via Iced.