### PR TITLE
Use both `x11` and `wayland` sockets to fix clipboard compatibility

### DIFF
--- a/org.squidowl.halloy.json
+++ b/org.squidowl.halloy.json
@@ -12,6 +12,7 @@
         "--share=ipc",
         "--share=network",
         "--socket=pulseaudio",
+        "--socket=wayland",
         "--socket=x11",
         "--talk-name=org.freedesktop.Notifications"
     ],


### PR DESCRIPTION
@tarkah until the [upstream issue](https://github.com/1Password/arboard/issues/223) regarding the clipboard is fixed, we have temporarily received an [exception](https://github.com/flathub-infra/flatpak-builder-lint/pull/1098) from flathub to use these two sockets together. This PR should be approved for publishing to the flathub store now.